### PR TITLE
Update test_readf.py

### DIFF
--- a/test_readf.py
+++ b/test_readf.py
@@ -75,7 +75,7 @@ class Test_Readf:
         file_length = ctypes.c_int(0)
         retval = libc.fs_readf(ctypes.byref(fs), ctypes.c_char_p(bytes("/fil1","utf-8")),ctypes.byref(file_length))
         assert file_length.value == len(teststring)
-        assert retval.decode("utf-8") == teststring
+        assert retval[: len(teststring)].decode("utf-8") == teststring
 
     def test_readf_wrong_input(self):
         fs = setup(5)


### PR DESCRIPTION
Fixed assert in test_readf_NULL_in_string
You shouldnt be checking for the whole length, instead decode for only the length of teststring. the output of readf shouldnt be NULL terminated, so it only makes sense to only check the size that is supposed to be read.